### PR TITLE
#13 - Use one popup for all togglers for perfs

### DIFF
--- a/packages/emogeez-react-components/src/EmojisPopupToggler/EmojisPopupToggler.stories.js
+++ b/packages/emogeez-react-components/src/EmojisPopupToggler/EmojisPopupToggler.stories.js
@@ -7,8 +7,8 @@ import { storiesOf } from '@storybook/react';
 import EmojisPopupToggler from './EmojisPopupToggler';
 import apple from '../../node_modules/emogeez-generator/emojis/apple/apple.json';
 
-const stories = storiesOf('EmojisPopupToggler', module)
-  .addDecorator(centered);
+const stories = storiesOf('EmojisPopupToggler', module);
+//.addDecorator(centered);
 
 stories.add('Default', () => {
   const props = {
@@ -62,6 +62,98 @@ stories.add('Placement from parentClass', () => {
   return (
     <div style={parentStyle} className="parentClass">
       <EmojisPopupToggler {...props} />
+    </div>
+  );
+});
+
+stories.add('Multiples togglers', () => {
+  const parent = {
+    style: {
+      width: 500,
+      height: 600,
+      border: '1px solid red',
+      position: 'relative',
+    },
+    className: 'parentClass',
+  };
+
+  const toggler1 = {
+    categories: map(apple, category => category),
+    onClickEmoji: console.log,
+    style: {
+      position: 'absolute',
+      top: 10,
+      right: 10,
+    },
+    containerClassNameForPlacement: 'parentClass',
+  };
+
+  const toggler2 = {
+    categories: map(apple, category => category),
+    onClickEmoji: console.log,
+    style: {
+      position: 'absolute',
+      right: 10,
+      bottom: 10,
+    },
+    containerClassNameForPlacement: 'parentClass',
+  };
+
+  const toggler3 = {
+    categories: map(apple, category => category),
+    onClickEmoji: console.log,
+    style: {
+      position: 'absolute',
+      bottom: 10,
+      left: 10,
+    },
+    containerClassNameForPlacement: 'parentClass',
+  };
+
+  const toggler4 = {
+    categories: map(apple, category => category),
+    onClickEmoji: console.log,
+    style: {
+      position: 'absolute',
+      left: 10,
+      top: 10,
+    },
+    containerClassNameForPlacement: 'parentClass',
+  };
+
+  const toggler5 = {
+    categories: map(apple, category => category),
+    onClickEmoji: console.log,
+    style: {
+      position: 'absolute',
+      right: 10,
+      top: 100,
+    },
+    togglerRenderer: () => (
+      <button className="customClassName">
+        position from window
+      </button>
+    ),
+  };
+
+  const toggler6 = {
+    categories: map(apple, category => category),
+    onClickEmoji: console.log,
+    style: {
+      position: 'absolute',
+      left: 250,
+      top: 300,
+    },
+  };
+
+  return (
+    <div {...parent}>
+      <EmojisPopupToggler {...toggler1} />
+      <EmojisPopupToggler {...toggler2} />
+      <EmojisPopupToggler {...toggler3} />
+      <EmojisPopupToggler {...toggler4} />
+      <EmojisPopupToggler {...toggler5} />
+      <EmojisPopupToggler {...toggler6} />
     </div>
   );
 });

--- a/packages/emogeez-react-components/src/EmojisPopupToggler/EmojisPopupToggler.test.js
+++ b/packages/emogeez-react-components/src/EmojisPopupToggler/EmojisPopupToggler.test.js
@@ -1,15 +1,13 @@
 import React from 'react';
-import sinon from 'sinon';
 import ReactTestUtils from 'react-dom/test-utils';
 import {
   expect,
-  assert,
 } from 'chai';
 import {
   map,
 } from 'lodash';
-import EmojisPopupToggler, { CLASSNAMES } from './EmojisPopupToggler.js';
 import apple from 'emogeez-generator/emojis/apple/apple.json';
+import EmojisPopupToggler, { CLASSNAMES } from './EmojisPopupToggler';
 
 const categories = map(apple, category => category);
 
@@ -20,7 +18,6 @@ const renderComponentIntoDOM = (props = {}) => ReactTestUtils.renderIntoDocument
 const story = {
   categories,
 };
-const onClickSpy = sinon.spy();
 
 describe('EmojisPopupToggler', () => {
   it('should accept custom classnames', () => {
@@ -37,12 +34,14 @@ describe('EmojisPopupToggler', () => {
   it('should open the popup onClick on toggler', () => {
     const component = renderComponentIntoDOM(story);
     const toggler = ReactTestUtils.findRenderedDOMComponentWithClass(component, CLASSNAMES.button);
-    const popup = ReactTestUtils.findRenderedDOMComponentWithClass(component, CLASSNAMES.popupWrapper);
+    let popup = ReactTestUtils.scryRenderedDOMComponentsWithClass(component, CLASSNAMES.popupWrapper);
 
-    expect(popup.className).to.equal('emojisPopupTogglerPopupWrapper');
+    expect(popup.length).to.equal(0);
     ReactTestUtils.Simulate.click(toggler);
+    popup = window.document.getElementById('emogeezPopup').children[0];
     expect(popup.className).to.equal('emojisPopupTogglerPopupWrapper opened');
     ReactTestUtils.Simulate.click(toggler);
+    popup = window.document.getElementById('emogeezPopup').children[0];
     expect(popup.className).to.equal('emojisPopupTogglerPopupWrapper');
   });
 

--- a/packages/emogeez-react-components/src/EmojisPopupToggler/_emojisPopupToggler.scss
+++ b/packages/emogeez-react-components/src/EmojisPopupToggler/_emojisPopupToggler.scss
@@ -1,38 +1,6 @@
 .emojisPopupTogglerContainer {
     position: relative;
 
-    .emojisPopupTogglerPopupWrapper {
-        animation-duration: 0.3s;
-        border: 1px solid $popupBorderColor;
-        box-shadow: 0 6px 12px 0 rgba(38, 40, 45, .2);
-        animation-fill-mode: both;
-        animation-name: slideInDown;
-        display: none;
-        border-radius: 5px;
-        visibility: hidden;
-        position: absolute;
-
-        &.opened {
-            display: block;
-            visibility: visible;
-        }
-    }
-
-    .emojisPopupTogglerArrow {
-        display: block;
-        width: 1rem;
-        height: 1rem;
-        border: 1px solid $popupBorderColor;
-        transform: rotate(-45deg);
-        position: absolute;
-        box-sizing: content-box;
-        background-color: white;
-    }
-
-    .emojisPopupTogglerPopup {
-
-    }
-
     .emojisPopupTogglerButton {
         background-color: transparent;
         border: 0;
@@ -46,6 +14,34 @@
         height: 16px;
         fill: #707689;
     }
+}
+
+.emojisPopupTogglerPopupWrapper {
+    animation-duration: 0.3s;
+    border: 1px solid $popupBorderColor;
+    box-shadow: 0 6px 12px 0 rgba(38, 40, 45, .2);
+    animation-fill-mode: both;
+    animation-name: slideInDown;
+    display: none;
+    border-radius: 5px;
+    visibility: hidden;
+    position: fixed;
+
+    &.opened {
+        display: block;
+        visibility: visible;
+    }
+}
+
+.emojisPopupTogglerArrow {
+    display: block;
+    width: 1rem;
+    height: 1rem;
+    border: 1px solid $popupBorderColor;
+    transform: rotate(-45deg);
+    position: absolute;
+    box-sizing: content-box;
+    background-color: white;
 }
 
 @keyframes slideInDown {

--- a/packages/emogeez-react-components/src/placement.js
+++ b/packages/emogeez-react-components/src/placement.js
@@ -19,7 +19,7 @@ const findParents = (element, classNames) => {
 const placePopup = (popup, toggler, offset, parentClass = null) => {
   const isFromWindow = parentClass === null;
   let parentNotFound = false;
-  let $parent = isFromWindow ? window : findParents(popup, parentClass);
+  let $parent = isFromWindow ? window : findParents(toggler, parentClass);
   if (!$parent) {
     parentNotFound = true;
     $parent = window;
@@ -36,48 +36,41 @@ const placePopup = (popup, toggler, offset, parentClass = null) => {
   const popupBox = popup.getBoundingClientRect();
   const togglerBox = toggler.getBoundingClientRect();
 
-  // /!\ placement computing here is relative to the parent
-  const newPlacement = {
-    top: 'auto',
-    left: 'auto',
-    right: 'auto',
-    bottom: 'auto',
-  };
-  const togglerCenter = togglerBox.left + (togglerBox.width / 2);
-  const parentCenter = parentBox.left + (parentBox.width / 2);
+  const togglerCenterX = togglerBox.left + (togglerBox.width / 2);
+  const togglerCenterY = togglerBox.top + (togglerBox.height / 2);
+  const parentCenterX = parentBox.left + (parentBox.width / 2);
+  const parentCenterY = parentBox.top + (parentBox.height / 2);
+
+  let nextTop = popupBox.top;
+  let nextLeft = popupBox.left;
 
   // if we are closer to the left
-  if (togglerCenter < parentCenter) {
-    let nextLeft = (togglerCenter - (popupBox.width / 2)) + offset;
+  if (togglerCenterX < parentCenterX) {
+    nextLeft = (togglerCenterX - (popupBox.width / 2));
     const outLeft = nextLeft - parentBox.left;
     if (outLeft < 0) {
       nextLeft += Math.abs(outLeft);
     }
-    newPlacement.left = nextLeft - togglerBox.left;
+    nextLeft += offset;
   } else {
-    let nextLeft = (togglerCenter - (popupBox.width / 2)) + offset;
+    nextLeft = (togglerCenterX - (popupBox.width / 2));
     const outRight = (parentBox.left + parentBox.width) - (nextLeft + popupBox.width);
     if (outRight < 0) {
       nextLeft -= Math.abs(outRight);
     }
-    newPlacement.left = nextLeft - togglerBox.left;
+    nextLeft -= offset;
   }
 
-  if ((togglerBox.top + (togglerBox.height / 2)) < parentBox.height / 2) {
-    newPlacement.top = togglerBox.height + offset;
-    if (popupBox.top <= 0) { // if popup is out of parent on top side
-      newPlacement.top += (-popupBox.top + offset); // we add to popup propertie the difference
-    }
-  }
-  const outBottom = parentBox.bottom - popupBox.bottom;
-  if (outBottom <= 0) {
-    newPlacement.bottom = togglerBox.height + offset;
+  if (togglerCenterY < parentCenterY) {
+    nextTop = togglerBox.top + togglerBox.height + offset;
+  } else {
+    nextTop = togglerBox.top - popupBox.height - offset;
   }
 
-  popup.style.top = newPlacement.top === 'auto' ? 'auto' : `${newPlacement.top}px`;
-  popup.style.left = newPlacement.left === 'auto' ? 'auto' : `${newPlacement.left}px`;
-  popup.style.right = newPlacement.right === 'auto' ? 'auto' : `${newPlacement.right}px`;
-  popup.style.bottom = newPlacement.bottom === 'auto' ? 'auto' : `${newPlacement.bottom}px`;
+  popup.style.setProperty('top', `${nextTop}px`);
+  popup.style.setProperty('left', `${nextLeft}px`);
+  popup.style.setProperty('right', 'auto');
+  popup.style.setProperty('bottom', 'auto');
 };
 
 /**
@@ -116,15 +109,12 @@ const placeArrow = (popup, toggler, arrow) => {
 export const placeEmojiPopup = (popup, toggler, offset, arrow, parentClass = null) => {
   const popupBox = popup.getBoundingClientRect();
   const togglerBox = toggler.getBoundingClientRect();
-  const style = popup.style;
 
-  style.top = `${togglerBox.height + offset}px`;
-  style.left = `${togglerBox.width / 2}px`;
-  style.right = 'auto';
-  style.bottom = 'auto';
-  style.marginLeft = `${-popupBox.width / 2}px`;
+  popup.style.setProperty('top', `${togglerBox.top + togglerBox.height + offset}px`);
+  popup.style.setProperty('left', `${togglerBox.left + (togglerBox.width / 2) - (popupBox.width / 2)}px`);
+  popup.style.setProperty('right', 'auto');
+  popup.style.setProperty('bottom', 'auto');
 
-  popup.style = style;
   placePopup(popup, toggler, offset, parentClass);
   placeArrow(popup, toggler, arrow);
 };


### PR DESCRIPTION
Render only one popup for all toggler for performances.

In case your application (as Flowdock or Slack etc...) has many inputs and many places to use an emoji popup, it may be really bad to render one popup by toggler (it will create X * 1800 dom nodes).
So in this PR, i render the popup only if there is a toggler used at least once.